### PR TITLE
Adding support for PowerShell version < 6

### DIFF
--- a/github_branch_rename.ps1
+++ b/github_branch_rename.ps1
@@ -71,13 +71,17 @@ function Get-GitHub-RepoRefs-Uri {
     $GitHubApi_RootUri + "/repos/{user_name}/{repo_name}/git/refs" -replace "{user_name}", $UserName -replace "{repo_name}", $RepoName
 }
 
+function Get-PSVersion {
+    if (test-path variable:psversiontable) {$psversiontable.psversion.Major} else {"-1"} 
+}
+
 function Rename-GitHub-Branches {
     Param (
 
-        [Parameter(Mandatory=$true)] [string] $GitHubToken, 
-        [Parameter(Mandatory=$true)] [string] $User, 
-        [Parameter(Mandatory=$true)] [string] $FromBranch, 
-        [Parameter(Mandatory=$true)] [string] $ToBranch,
+        [Parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [string] $GitHubToken, 
+        [Parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [string] $User, 
+        [Parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [string] $FromBranch, 
+        [Parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [string] $ToBranch,
         [Parameter(Mandatory=$false)] [string] $ApiRootUri = 'https://api.github.com' 
     )
     
@@ -87,7 +91,16 @@ function Rename-GitHub-Branches {
     $script:GitHubApi_Headers = @{'Authorization' = 'Bearer ' + $GitHubToken}
 
     $userRepoUri = Get-GitHub-UserRepos-Uri $GitHubUser
-    $reposFromApi = Invoke-RestMethod -Uri $userRepoUri -Headers $GitHubApi_Headers -FollowRelLink -MaximumFollowRelLink 5
+
+    $version = Get-PSVersion
+    if ($version -lt 6)
+    {
+        $reposFromApi = Invoke-RestMethod -Uri $userRepoUri -Headers $GitHubApi_Headers
+    }
+    else
+    {
+        $reposFromApi = Invoke-RestMethod -Uri $userRepoUri -Headers $GitHubApi_Headers -FollowRelLink -MaximumFollowRelLink 5
+    }
 
     $repos = @()
     $userRepos = @()


### PR DESCRIPTION
I liked the idea of having a common branch-renamer however when I tried in local I faced an issue due to PS version being < 6.

Not sure if it adds value or not, just thought of adding support for PS version < 6 and some validation (It introduces a limitation that only page 1 (30) repositories will get renamed, still debating if we have to add parsing header and get the next page URL and repeat 5 times to match with PS > 6 condition)    